### PR TITLE
explicitly convert hashes to uppercase strings

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -105,7 +105,7 @@ int startCommandLineApp(int argc, char* argv[]) {
                 auto num_worker_threads = miner.numWorkerThreads();
                 auto cps = miner.numChecksPerSecond();
                 std::cout << "Newest Block Index: " << block->header.block_uid << std::endl <<
-                          "Newest Block Hash: " << block->header.generic_header.block_hash.str(0, std::ios_base::hex) << std::endl <<
+                          "Newest Block Hash: " << block->header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << std::endl <<
                           "Balance: " << std::fixed << std::setprecision(6) << static_cast<double>(blockchain.getBalance(public_key)) /
                           static_cast<double>(scn::TransactionSubBlock::fraction_per_coin) << std::endl <<
                           "Peers: " << (num_peers>0 ? "\033[1;32m" : "\033[1;31m") << num_peers << "\033[0m" << "\t\t" <<

--- a/src/scn/Blockchain/BlockDefinitions.cpp
+++ b/src/scn/Blockchain/BlockDefinitions.cpp
@@ -21,8 +21,8 @@ using namespace scn;
 
 std::ostream& scn::operator<<(std::ostream& os, const BaseBlock& block) {
     os << "Block " << block.header.block_uid << std::endl;
-    os << "   hash: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex) << std::endl;
-    os << "   previous_block_hash: " << block.header.generic_header.previous_block_hash.str(0, std::ios_base::hex)
+    os << "   hash: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << std::endl;
+    os << "   previous_block_hash: " << block.header.generic_header.previous_block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase)
        << std::endl;
     os << "   type: " << (uint32_t)block.header.generic_header.block_type << std::endl;
     return os;
@@ -39,7 +39,7 @@ std::ostream& scn::operator<<(std::ostream& os, const BaselineBlock& block) {
     for(uint32_t epoch = 0;epoch < block.data_value_hashes.size();epoch++) {
         os << "    epoch " << epoch << ": " << block.data_value_hashes[epoch].size() << std::endl;
         for(auto& data_value_hash : block.data_value_hashes[epoch]) {
-            os << "     " << data_value_hash.str(0, std::ios_base::hex) << std::endl;
+            os << "     " << data_value_hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << std::endl;
         }
 
     }
@@ -64,8 +64,8 @@ std::ostream& scn::operator<<(std::ostream& os, const CollectionBlock& block) {
 
 std::ostream& scn::operator<<(std::ostream& os, const TransactionSubBlock& block) {
     os << "TransactionSubBlock " << std::endl;
-    os << "   hash: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex) << std::endl;
-    os << "   previous_block_hash: " << block.header.generic_header.previous_block_hash.str(0, std::ios_base::hex)
+    os << "   hash: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << std::endl;
+    os << "   previous_block_hash: " << block.header.generic_header.previous_block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase)
        << std::endl;
     os << "   type: " << (uint32_t)block.header.generic_header.block_type << std::endl;
     os << "   fraction: " << block.fraction << std::endl;
@@ -78,8 +78,8 @@ std::ostream& scn::operator<<(std::ostream& os, const TransactionSubBlock& block
 
 std::ostream& scn::operator<<(std::ostream& os, const CreationSubBlock& block) {
     os << "CreationSubBlock " << std::endl;
-    os << "   hash: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex) << std::endl;
-    os << "   previous_block_hash: " << block.header.generic_header.previous_block_hash.str(0, std::ios_base::hex)
+    os << "   hash: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << std::endl;
+    os << "   previous_block_hash: " << block.header.generic_header.previous_block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase)
        << std::endl;
     os << "   type: " << (uint32_t)block.header.generic_header.block_type << std::endl;
     //os << "   data value: " << block.data_value << std::endl;

--- a/src/scn/Blockchain/Blockchain.cpp
+++ b/src/scn/Blockchain/Blockchain.cpp
@@ -160,7 +160,7 @@ block_uid_t Blockchain::establishBaseline() {
         LOG(INFO) << "  filled hash";
         google::FlushLogFiles(google::GLOG_INFO);
         this_block_id = cache_.addBlock(current_baseline_);
-        LOG(INFO) << "New Baseline " << current_baseline_.header.block_uid << ": " << current_baseline_.header.generic_header.block_hash.str(0, std::ios_base::hex);
+        LOG(INFO) << "New Baseline " << current_baseline_.header.block_uid << ": " << current_baseline_.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
         google::FlushLogFiles(google::GLOG_INFO);
         current_baseline_.header.generic_header.block_hash = 0;
 
@@ -300,7 +300,7 @@ bool Blockchain::validateBlockWithoutContext(const BaselineBlock& block) {
     for(auto& epoch_hashes : block.data_value_hashes) {
         for(auto it = epoch_hashes.begin() ; it != epoch_hashes.end() ; it++) {
             if((it+1) != epoch_hashes.end() && *it == *(it+1)) {
-                LOG(ERROR) << "validateBlock: duplicate data_value hash found: " << it->str(0, std::ios_base::hex);
+                LOG(ERROR) << "validateBlock: duplicate data_value hash found: " << it->str(0, std::ios_base::hex | std::ios_base::uppercase);
                 return false;
             }
         }
@@ -617,10 +617,10 @@ bool Blockchain::validateSubBlock(const CreationSubBlock& sub_block,
 
     //check data value content (begins with public key and previous hash)
     if( !boost::starts_with(sub_block.data_value,
-                            mining_state.highest_hash_of_last_epoch.str(0, std::ios_base::hex) + "_" +
+                            mining_state.highest_hash_of_last_epoch.str(0, std::ios_base::hex | std::ios_base::uppercase) + "_" +
                                     sub_block.creator.getAsShortString() + "_")) {
         LOG(ERROR) << "validateSubBlock: data_value beginning invalid" /*<< std::endl
-                   << "expected: " << mining_state.highest_hash_of_last_epoch.str(0, std::ios_base::hex) + "_" + sub_block.creator + "_" << std::endl
+                   << "expected: " << mining_state.highest_hash_of_last_epoch.str(0, std::ios_base::hex | std::ios_base::uppercase) + "_" + sub_block.creator + "_" << std::endl
                    << "found:    " << sub_block.data_value*/;
         return false;
     }
@@ -628,7 +628,7 @@ bool Blockchain::validateSubBlock(const CreationSubBlock& sub_block,
     //check data value hash area
     hash_t data_value_hash = CryptoHelper::calcHash(sub_block.data_value);
     if(data_value_hash < min_allowed_hash || data_value_hash > max_allowed_hash) {
-        LOG(ERROR) << "validateSubBlock: Data value hash area mismatch!" << std::endl << data_value_hash.str(0, std::ios_base::hex) << std::endl << sub_block.data_value << std::endl << "min/max:" << min_allowed_hash.str(0, std::ios_base::hex) << "/" << max_allowed_hash.str(0, std::ios_base::hex);
+        LOG(ERROR) << "validateSubBlock: Data value hash area mismatch!" << std::endl << data_value_hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << std::endl << sub_block.data_value << std::endl << "min/max:" << min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << "/" << max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
         return false;
     }
 
@@ -640,7 +640,7 @@ bool Blockchain::validateSubBlock(const CreationSubBlock& sub_block,
 
     //check if data_value is already in blockchain
     if(std::binary_search(data_value_hashes_of_epoch.begin(), data_value_hashes_of_epoch.end(), data_value_hash)) {
-        LOG(ERROR) << "validateSubBlock: data_value already found in blockchain: " << data_value_hash.str(0, std::ios_base::hex);
+        LOG(ERROR) << "validateSubBlock: data_value already found in blockchain: " << data_value_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
         return false;
     }
 
@@ -671,7 +671,7 @@ void Blockchain::writeDataValueHashesToFile(const std::string& filename) {
         ofs << "Epoch: " << epoch << ": " << current_baseline_.data_value_hashes[epoch].size() << std::endl;
     }
     for(auto& hash : current_baseline_.data_value_hashes.back()) {
-        ofs << "  " << hash.str(0, std::ios_base::hex) << std::endl;
+        ofs << "  " << hash.str(0, std::ios_base::hex | std::ios_base::uppercase) << std::endl;
     }
 }
 

--- a/src/scn/BlockchainManager/CycleStateFetchBlockchain.cpp
+++ b/src/scn/BlockchainManager/CycleStateFetchBlockchain.cpp
@@ -70,7 +70,7 @@ void CycleStateFetchBlockchain::blockReceivedCallback(IPeer& peer, const Baselin
             if(Blockchain::validateBlockWithoutContext(block)) {
                 base_.blockchain_.setRootBlock(block);
                 LOG(INFO) << "Fetched block " << block.header.block_uid << ": "
-                          << block.header.generic_header.block_hash.str(0, std::ios_base::hex);
+                          << block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
                 {
                     LOCK_MUTEX_WATCHDOG(mtx_next_block_to_ask_for_);
                     next_block_to_ask_for_ = block.header.block_uid + 1;
@@ -83,7 +83,7 @@ void CycleStateFetchBlockchain::blockReceivedCallback(IPeer& peer, const Baselin
         else {
             LOG(INFO) << "Ignoring received baseline block: "
                       << block.header.block_uid << ": "
-                      << block.header.generic_header.block_hash.str(0, std::ios_base::hex);
+                      << block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
         }
     } else {
         synchronized_ = (block.header.block_uid == base_.blockchain_.getNewestBlockId()+1);
@@ -97,7 +97,7 @@ void CycleStateFetchBlockchain::blockReceivedCallback(IPeer& peer, const Collect
             if (base_.blockchain_.validateBlock(block)) {
                 base_.blockchain_.addBlock(block);
                 LOG(INFO) << "Fetched block " << block.header.block_uid << ": "
-                          << block.header.generic_header.block_hash.str(0, std::ios_base::hex);
+                          << block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
                 {
                     LOCK_MUTEX_WATCHDOG(mtx_next_block_to_ask_for_);
                     next_block_to_ask_for_ = block.header.block_uid + 1;

--- a/src/scn/BlockchainManager/CycleStateIntroduceBlock.cpp
+++ b/src/scn/BlockchainManager/CycleStateIntroduceBlock.cpp
@@ -44,7 +44,7 @@ void CycleStateIntroduceBlock::onEnter() {
     base_.new_block_.header.generic_header.block_hash = 0;
     CryptoHelper::fillHash(base_.new_block_);
 
-    LOG(INFO) << "Propagate initial block: " << base_.new_block_.header.generic_header.block_hash.str(0, std::ios_base::hex);
+    LOG(INFO) << "Propagate initial block: " << base_.new_block_.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
     base_.p2p_connector_.propagateBlock(base_.new_block_);
     next_propagation_time_ = base_.sync_timer_.now() + time_between_propagations_ms_;
 }
@@ -53,7 +53,7 @@ void CycleStateIntroduceBlock::onEnter() {
 bool CycleStateIntroduceBlock::onCycle() {
     if(base_.sync_timer_.now() >= next_propagation_time_) {
         next_propagation_time_ += time_between_propagations_ms_;
-        LOG(INFO) << "Propagate updated block: " << base_.new_block_.header.generic_header.block_hash.str(0, std::ios_base::hex);
+        LOG(INFO) << "Propagate updated block: " << base_.new_block_.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
         base_.p2p_connector_.propagateBlock(base_.new_block_);
     }
     return false;
@@ -75,8 +75,8 @@ void CycleStateIntroduceBlock::onExit() {
         base_.resumeMiner();
     }
 
-    LOG(INFO) << "New Block " << base_.new_block_.header.block_uid << ": " << base_.new_block_.header.generic_header.block_hash.str(0, std::ios_base::hex);
-    LOG(INFO) << "      highest_hash_of_last_epoch: " << mining_state.highest_hash_of_last_epoch.str(0, std::ios_base::hex);
+    LOG(INFO) << "New Block " << base_.new_block_.header.block_uid << ": " << base_.new_block_.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
+    LOG(INFO) << "      highest_hash_of_last_epoch: " << mining_state.highest_hash_of_last_epoch.str(0, std::ios_base::hex | std::ios_base::uppercase);
     LOG(INFO) << "Balance: " << static_cast<double>(base_.blockchain_.getBalance(base_.our_public_key_)) /
             static_cast<double>(TransactionSubBlock::fraction_per_coin);
 }
@@ -88,7 +88,7 @@ void CycleStateIntroduceBlock::blockReceivedCallback(IPeer& peer, const Collecti
         base_.peers_monitor_.reportViolation(peer);
         return;
     }
-    LOG(INFO) << "CycleStateIntroduceBlock incoming block: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex);
+    LOG(INFO) << "CycleStateIntroduceBlock incoming block: " << block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase);
     if(block.header.block_uid != base_.new_block_.header.block_uid) {
         LOG(INFO) << "  Ignoring block (unexpected block id " << block.header.block_uid << ")";
     } else if(processed_blocks_.find(block.header.generic_header.block_hash) != processed_blocks_.end()) {

--- a/src/scn/Miner/MinerLocal.cpp
+++ b/src/scn/Miner/MinerLocal.cpp
@@ -122,12 +122,12 @@ uint64_t MinerLocal::numChecksPerSecond() const {
 void MinerLocal::miningThread(uint32_t thread_id)
 {
     std::string random_prefix = std::to_string(std::rand() % 1000000000);
-    std::string prefix = previous_epoch_highest_hash_.str(0, std::ios_base::hex) + "_" +
+    std::string prefix = previous_epoch_highest_hash_.str(0, std::ios_base::hex | std::ios_base::uppercase) + "_" +
             owner_public_key_.getAsShortString() + "_" + random_prefix + "_";
 
     boost::multiprecision::uint1024_t value = 0;
     while(running_) {
-        std::string string_to_hash = prefix + value.str(0, std::ios_base::hex);
+        std::string string_to_hash = prefix + value.str(0, std::ios_base::hex | std::ios_base::uppercase);
         auto hash = CryptoHelper::calcHash(string_to_hash);
         stats_check_counter_++;
         if (hash >= min_allowed_value_ && hash <= max_allowed_value_) {

--- a/test/TestBlockchain.cpp
+++ b/test/TestBlockchain.cpp
@@ -193,56 +193,56 @@ TEST_F(TestBlockchain, HashAreaCalculation) {
     hash_t max_allowed_hash, min_allowed_hash;
 
     Blockchain::getHashArea(1, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "FF8BCFF3EDF1A8D2A0B4C276EA5769595237ADB6C2B194E46E60508026B3F88A");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "FF17D4A36FD835FB55D7162AC718802635934A167AEBC33A24F3B15EC9E1D7EC");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "FF8BCFF3EDF1A8D2A0B4C276EA5769595237ADB6C2B194E46E60508026B3F88A");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "FF17D4A36FD835FB55D7162AC718802635934A167AEBC33A24F3B15EC9E1D7EC");
 
     Blockchain::getHashArea(2, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "FF17D4A36FD835FB55D7162AC718802635934A167AEBC33A24F3B15EC9E1D7EB");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "FEA40DF696CEF441A97C7A4364F3D15959B48EA4C4598F516C2A861391326FE8");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "FF17D4A36FD835FB55D7162AC718802635934A167AEBC33A24F3B15EC9E1D7EB");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "FEA40DF696CEF441A97C7A4364F3D15959B48EA4C4598F516C2A861391326FE8");
 
     Blockchain::getHashArea(10, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "FB7F59513683B463ED042DE87F9A854A074FDF5D7DD21A51D9084BCAF6F4D29B");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "FB0D346901428BCB7D1BDF4B3F20F6FF9B683A8A749BED1A609BB630AA3E046A");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "FB7F59513683B463ED042DE87F9A854A074FDF5D7DD21A51D9084BCAF6F4D29B");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "FB0D346901428BCB7D1BDF4B3F20F6FF9B683A8A749BED1A609BB630AA3E046A");
 
     Blockchain::getHashArea(100, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "D66045854E95A666A09AC8A4DFC65C23CD709A96E6547A50601945233625E6F0");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "D5FEF9A9A583027398B8E406D8FD3FAEE07A27922DBE6FF2917FFB2335DEC256");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "D66045854E95A666A09AC8A4DFC65C23CD709A96E6547A50601945233625E6F0");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "D5FEF9A9A583027398B8E406D8FD3FAEE07A27922DBE6FF2917FFB2335DEC256");
 
     Blockchain::getHashArea(1000, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "2B694D7A8004BB80D67B6B87343ED2DA2A5CCAA60817ADB2B847D4050998E48A");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "2B55999D99FC499FA805DDD45D78775E1F217405AFB3110EAF3987EF0E4CFA6A");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "2B694D7A8004BB80D67B6B87343ED2DA2A5CCAA60817ADB2B847D4050998E48A");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "2B55999D99FC499FA805DDD45D78775E1F217405AFB3110EAF3987EF0E4CFA6A");
 
     Blockchain::getHashArea(10000, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "5472D14EE5C57F9ADF9C16F6669995B78C186971500CF8AE48EE0FF907");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "544C7D6E8B6FF994450742B5B1351991323A12D41B062F69C0A33022B6");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "5472D14EE5C57F9ADF9C16F6669995B78C186971500CF8AE48EE0FF907");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "544C7D6E8B6FF994450742B5B1351991323A12D41B062F69C0A33022B6");
 
     Blockchain::getHashArea(50000, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "1000000000717EE28BDCEB8D62AB0E5A5");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "FF8BCFF3F5065ECEA1C697A964488DBB");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "1000000000717EE28BDCEB8D62AB0E5A5");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "FF8BCFF3F5065ECEA1C697A964488DBB");
 
     Blockchain::getHashArea(92536, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "89DD9");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "899F0");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "89DD9");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "899F0");
 
     Blockchain::getHashArea(92537, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "899EF");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "89608");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "899EF");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "89608");
 
     Blockchain::getHashArea(92538, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "89607");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "89222");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "89607");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "89222");
 
     Blockchain::getHashArea(95000, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "1AC3");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "1AB7");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "1AC3");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "1AB7");
 
     Blockchain::getHashArea(96755, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "1");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "1");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "1");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "1");
 
     Blockchain::getHashArea(96756, max_allowed_hash, min_allowed_hash);
-    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex), "0");
-    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex), "0");
+    EXPECT_EQ(max_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "0");
+    EXPECT_EQ(min_allowed_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "0");
 }
 
 

--- a/test/TestCrypto.cpp
+++ b/test/TestCrypto.cpp
@@ -21,14 +21,14 @@ using namespace scn;
 
 TEST(TestCrypto, HashCalculationShort) {
     auto hash = CryptoHelper::calcHash("A random text.");
-    EXPECT_EQ(hash.str(0, std::ios_base::hex), "1FF38799705BD4B5CEAA66EE3DEC54A304E16B64A1711838730EFF6752F2BA6");
+    EXPECT_EQ(hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "1FF38799705BD4B5CEAA66EE3DEC54A304E16B64A1711838730EFF6752F2BA6");
 }
 
 TEST(TestCrypto, HashCalculationShortStream) {
     std::stringstream ss;
     ss << "A random text.";
     auto hash = CryptoHelper::calcHash(ss);
-    EXPECT_EQ(hash.str(0, std::ios_base::hex), "1FF38799705BD4B5CEAA66EE3DEC54A304E16B64A1711838730EFF6752F2BA6");
+    EXPECT_EQ(hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "1FF38799705BD4B5CEAA66EE3DEC54A304E16B64A1711838730EFF6752F2BA6");
 }
 
 void buildLongStringStream(std::stringstream& ss) {
@@ -42,12 +42,12 @@ TEST(TestCrypto, HashCalculationLong) {
     std::stringstream ss;
     buildLongStringStream(ss);
     auto hash = CryptoHelper::calcHash(ss.str());
-    EXPECT_EQ(hash.str(0, std::ios_base::hex), "D428F80D2822CFF295B9746FA9D4D10B497EB3EC0D2B63A562425D69EAB9C5A7");
+    EXPECT_EQ(hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "D428F80D2822CFF295B9746FA9D4D10B497EB3EC0D2B63A562425D69EAB9C5A7");
 }
 
 TEST(TestCrypto, HashCalculationLongStream) {
     std::stringstream ss;
     buildLongStringStream(ss);
     auto hash = CryptoHelper::calcHash(ss);
-    EXPECT_EQ(hash.str(0, std::ios_base::hex), "D428F80D2822CFF295B9746FA9D4D10B497EB3EC0D2B63A562425D69EAB9C5A7");
+    EXPECT_EQ(hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "D428F80D2822CFF295B9746FA9D4D10B497EB3EC0D2B63A562425D69EAB9C5A7");
 }

--- a/test/TestSerialization.cpp
+++ b/test/TestSerialization.cpp
@@ -70,7 +70,7 @@ TEST(TestSerialization, CollectionBlockHashSimple) {
     block.header.block_uid = 17;
     block.header.generic_header.previous_block_hash = 123;
     CryptoHelper::fillHash(block);
-    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex), "92AB50CAA4A584A6A2953A0DC1E5FBFCD0C2981DE1478241F309BE67A275616D");
+    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "92AB50CAA4A584A6A2953A0DC1E5FBFCD0C2981DE1478241F309BE67A275616D");
 }
 
 TEST(TestSerialization, CollectionBlockHashExt) {
@@ -93,21 +93,21 @@ TEST(TestSerialization, CollectionBlockHashExt) {
     creation_block.creator = PublicKeyPEM("-----BEGIN PUBLIC KEY-----\nCREATOR\n-----END PUBLIC KEY-----");
     block.creations[creation_block.header.generic_header.block_hash] = creation_block;
     CryptoHelper::fillHash(block);
-    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex), "4EC67F2C53743DBF3A8AB740BBDDBC03747D30DDFF390CBC7AA6E891E6D418FC");
+    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "4EC67F2C53743DBF3A8AB740BBDDBC03747D30DDFF390CBC7AA6E891E6D418FC");
 
     block.header.generic_header.block_hash = 0;
     CryptoHelper::fillHash(block);
-    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex), "4EC67F2C53743DBF3A8AB740BBDDBC03747D30DDFF390CBC7AA6E891E6D418FC");
+    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "4EC67F2C53743DBF3A8AB740BBDDBC03747D30DDFF390CBC7AA6E891E6D418FC");
 
     block.header.block_uid = 18;
     block.header.generic_header.block_hash = 0;
     CryptoHelper::fillHash(block);
-    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex), "B504DEEA975CC25FF94693EF83670E7B86E45BB112E3621490AF53413FD312C1");
+    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "B504DEEA975CC25FF94693EF83670E7B86E45BB112E3621490AF53413FD312C1");
 
     block.transactions.begin()->second.fraction++;
     block.header.generic_header.block_hash = 0;
     CryptoHelper::fillHash(block);
-    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex), "39C25ECDD3579899F2B713FB1C95D674DCCE46797E98E7A60D7E2E5A2DA14B4E");
+    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "39C25ECDD3579899F2B713FB1C95D674DCCE46797E98E7A60D7E2E5A2DA14B4E");
 }
 
 std::vector<scn::public_key_t> example_pub_keys = {PublicKeyPEM("-----BEGIN PUBLIC KEY-----\n"
@@ -165,7 +165,7 @@ TEST(TestSerialization, BaselineBlockHashHuge) {
     t3 = std::chrono::system_clock::now();
     std::cout << "Generate Data: " << (std::chrono::duration_cast<std::chrono::milliseconds>(t2 - t1)).count() << "ms" << std::endl
               << "Fill Hash: " << (std::chrono::duration_cast<std::chrono::milliseconds>(t3 - t2)).count() << "ms" << std::endl;
-    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex), "BCE609969E259DBA1318A1E6263F4F2872FEB9E11F2C2D37F3E20E4C501C7BB2");
+    EXPECT_EQ(block.header.generic_header.block_hash.str(0, std::ios_base::hex | std::ios_base::uppercase), "BCE609969E259DBA1318A1E6263F4F2872FEB9E11F2C2D37F3E20E4C501C7BB2");
 }
 
 int main(int argc, char **argv) {


### PR DESCRIPTION
Hello,

this pull requests adds **std::ios_base::uppercase** to all hash-to-string conversions to produce uppercase results.

I cannot pinpoint why I get default lowercase conversion with Arch Linux and default uppercase conversion with Ubuntu Bionic, but I suspect either Boost or stdlib changing its default behaviour in between versions.

Anyway, being explicit is always better in such cases, so here's a pull request, as I fear that a future Ubuntu version will also run into the same trouble.

Works for me on both Arch Linux and Ubuntu Bionic.

Thank you for your work,

Blutkoete
(proud Badenian ;))