### PR TITLE
Cherry-picked Fix for Boost 1.72 from libtorrent-rasterbar 1.2.3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,9 @@
+/.idea/
+/build/
 /cmake-build-debug/
 /cmake-build-debug-ccache/
-/cmake-build-release-ccache/
-/.idea/
-/cmake-build-debug-visual-studio/
 /cmake-build-debug-mingw/
-/build/
+/cmake-build-debug-visual-studio/
+/cmake-build-release/
+/cmake-build-release-ccache/
+/cmake-build-releasewithtests

--- a/dep/libtorrent-rasterbar-1.2.2_extended/include/libtorrent/aux_/socket_type.hpp
+++ b/dep/libtorrent-rasterbar-1.2.2_extended/include/libtorrent/aux_/socket_type.hpp
@@ -184,6 +184,10 @@ namespace aux {
 		using receive_buffer_size = tcp::socket::receive_buffer_size;
 		using send_buffer_size = tcp::socket::send_buffer_size;
 
+#if BOOST_VERSION >= 106600
+		using executor_type = tcp::socket::executor_type;
+#endif
+
 		explicit socket_type(io_service& ios): m_io_service(ios), m_type(0) {}
 		~socket_type();
 


### PR DESCRIPTION
I cherry-picked the fix from libtorrent-rasterbar 1.2.3 that makes the library compile with Boost 1.72; as the fix explicitly checks for the Boost version, it should not break Ubuntu 18.04, but I cannot test that.

In addition, I allowed myself to add some folder names to .gitignore if you don't mind (it's ok if you do).

99 tests passed on my machine.
